### PR TITLE
Passing true values for isSelected and cellHasFocus in BasicJListCellReader

### DIFF
--- a/fest-swing/src/main/java/org/fest/swing/driver/BasicJListCellReader.java
+++ b/fest-swing/src/main/java/org/fest/swing/driver/BasicJListCellReader.java
@@ -20,6 +20,7 @@ import static org.fest.swing.driver.ModelValueToString.asText;
 import java.awt.Component;
 
 import javax.swing.JList;
+import javax.swing.ListSelectionModel;
 
 import org.fest.swing.annotation.RunsInCurrentThread;
 import org.fest.swing.cell.JListCellReader;
@@ -69,7 +70,10 @@ public class BasicJListCellReader implements JListCellReader {
   @RunsInCurrentThread
   public String valueAt(JList list, int index) {
     Object element = list.getModel().getElementAt(index);
-    Component c = list.getCellRenderer().getListCellRendererComponent(list, element, index, true, true);
+    ListSelectionModel lsm = list.getSelectionModel();
+	boolean isSelected = lsm.isSelectedIndex(index);
+	boolean cellHasFocus = list.hasFocus() && lsm.getLeadSelectionIndex() == index;
+    Component c = list.getCellRenderer().getListCellRendererComponent(list, element, index, isSelected, cellHasFocus);
     String value = (c != null) ? rendererReader.valueFrom(c) : null;
     if (value != null) return value;
     return asText(element);


### PR DESCRIPTION
In our project we have a list, that is rendered using checkboxes, whose state is determined by the list selection. In order to test the correct behavior of the list we had to implement an own ListCellReader who sets the isSelected property correctly, instead of just providing a CellRendererReader capable of handling checkboxes. Would be nice to have this included in future versions of the framework!
