### PR TITLE
Remove dependency on JDK1.5 for swing-TestNG

### DIFF
--- a/fest-swing-testng/pom.xml
+++ b/fest-swing-testng/pom.xml
@@ -37,7 +37,6 @@
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>5.7</version>
-      <classifier>jdk15</classifier>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Removed the line that forced the TestNG libraries to rely on JDK1.5. This line forced Gradle builds to decrease the target version to 1.5.
